### PR TITLE
Add CI for supported ROS distros

### DIFF
--- a/.github/workflows/kinetic.yaml
+++ b/.github/workflows/kinetic.yaml
@@ -1,0 +1,24 @@
+name: build-kinetic
+
+on: [push, pull_request]
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  industrial_ci:
+    strategy:
+      matrix:
+        env:
+          - {ROS_DISTRO: kinetic, ROS_REPO: main}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Create src directory for xs
+        run: |
+          rm interbotix_ros_xseries/CATKIN_IGNORE
+          mkdir src
+          mv interbotix_ros_xseries src
+      - uses: 'ros-industrial/industrial_ci@master'
+        env: ${{matrix.env}}

--- a/.github/workflows/melodic.yaml
+++ b/.github/workflows/melodic.yaml
@@ -1,0 +1,24 @@
+name: build-melodic
+
+on: [push, pull_request]
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  industrial_ci:
+    strategy:
+      matrix:
+        env:
+          - {ROS_DISTRO: melodic, ROS_REPO: main}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Create src directory for xs
+        run: |
+          rm interbotix_ros_xseries/CATKIN_IGNORE
+          mkdir src
+          mv interbotix_ros_xseries src
+      - uses: 'ros-industrial/industrial_ci@master'
+        env: ${{matrix.env}}

--- a/.github/workflows/noetic.yaml
+++ b/.github/workflows/noetic.yaml
@@ -1,0 +1,24 @@
+name: build-noetic
+
+on: [push, pull_request]
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  industrial_ci:
+    strategy:
+      matrix:
+        env:
+          - {ROS_DISTRO: noetic,  ROS_REPO: main}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Create src directory for xs
+        run: |
+          rm interbotix_ros_xseries/CATKIN_IGNORE
+          mkdir src
+          mv interbotix_ros_xseries src
+      - uses: 'ros-industrial/industrial_ci@master'
+        env: ${{matrix.env}}

--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ Coming soon...
 
 Support-level software can be found in the [interbotix_ros_toolboxes](https://github.com/Interbotix/interbotix_ros_toolboxes) repository
 
+### Build Status
+![build-kinetic status](https://github.com/Interbotix/interbotix_ros_core/actions/workflows/kinetic.yaml/badge.svg)
+![build-melodic Status](https://github.com/Interbotix/interbotix_ros_core/actions/workflows/melodic.yaml/badge.svg)
+![build-noetic Status](https://github.com/Interbotix/interbotix_ros_core/actions/workflows/noetic.yaml/badge.svg)
+
 ## Repo Structure
 ```
 GitHub Landing Page: Explains repository structure and contains a single directory for each type of actuator.


### PR DESCRIPTION
Use GitHub actions and ROS-Industrial CI to run continuous integration build tests