### PR TITLE
[xs_sdk] Report joint names when found

### DIFF
--- a/interbotix_ros_xseries/interbotix_xs_sdk/src/xs_sdk_obj.cpp
+++ b/interbotix_ros_xseries/interbotix_xs_sdk/src/xs_sdk_obj.cpp
@@ -546,11 +546,11 @@ bool InterbotixRobotXS::robot_ping_motors(void)
     bool result = dxl_wb.ping(motor.second.motor_id, &model_number);
     if (result == false)
     {
-      ROS_ERROR("[xs_sdk] Can't find Dynamixel ID '%d', joint name '%s'", motor.second.motor_id, motor.first.c_str());
+      ROS_ERROR("[xs_sdk] Can't find Dynamixel ID '%d', Joint Name : '%s'", motor.second.motor_id, motor.first.c_str());
       success = false;
     }
     else 
-      ROS_INFO("[xs_sdk] ID : %d, Model Number : %d", motor.second.motor_id, model_number);
+      ROS_INFO("[xs_sdk] Found Dynamixel ID : %d, Joint Name : %s, Model Number : %d", motor.second.motor_id, motor.first.c_str(), model_number);
     dxl_wb.torque(motor.second.motor_id, false);
   }
   return success;


### PR DESCRIPTION
Joints names were only mentioned when not found. The xs_sdk node will now also report them when they are found.