### PR TITLE
[xs_sdk] Handle bad service calls

### DIFF
--- a/interbotix_ros_xseries/interbotix_xs_sdk/include/interbotix_xs_sdk/xs_sdk_obj.h
+++ b/interbotix_ros_xseries/interbotix_xs_sdk/include/interbotix_xs_sdk/xs_sdk_obj.h
@@ -302,6 +302,13 @@ private:
   /// @details - refer to the service definition for details
   bool robot_srv_get_motor_registers(interbotix_xs_msgs::RegisterValues::Request &req, interbotix_xs_msgs::RegisterValues::Response &res);
 
+  /// @brief Checks service call requests for validity
+  /// @param cmd_type request cmd_type field
+  /// @param name request name field
+  /// @returns true if the service call request is valid, false otherwise
+  /// @details cmd_type must be 'single' or 'group'; name must be in the group_map or motor_map
+  bool robot_srv_validate(const std::string &cmd_type, std::string &name);
+
   /// @brief ROS One-Shot Timer used to step through a commanded joint trajectory
   /// @param e - TimerEvent message [unused]
   void robot_execute_trajectory(const ros::TimerEvent &e);


### PR DESCRIPTION
Fix bad service calls crashing the xs_sdk node by validating cmd_type and name fields before sending to service handles. Minor changes to debug logging statements.