### PR TITLE
Fix linker error `undefined reference: YAML::...`

### DIFF
--- a/interbotix_ros_xseries/interbotix_xs_sdk/CMakeLists.txt
+++ b/interbotix_ros_xseries/interbotix_xs_sdk/CMakeLists.txt
@@ -33,7 +33,6 @@ find_library(YAML_CPP_LIBRARY
   NAMES YAML_CPP
   PATHS ${YAML_CPP_LIBRARY_DIRS}
 )
-link_directories(${YAML_CPP_LIBRARY_DIRS})
 
 if(NOT ${YAML_CPP_VERSION} VERSION_LESS "0.5")
 add_definitions(-DHAVE_NEW_YAMLCPP)
@@ -67,6 +66,7 @@ include_directories(
 add_library(${PROJECT_NAME}
   src/xs_sdk_obj.cpp
 )
+target_link_libraries(${PROJECT_NAME} PUBLIC ${YAML_CPP_LIBRARIES})
 add_dependencies(${PROJECT_NAME} ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 
 ## Declare a C++ executable


### PR DESCRIPTION
I'm getting `ld.lld: error: undefined reference: YAML::...` error when compiling packages that depend on `interbotix_xs_sdk` such as `interbotix_xsarm_joy`:

```
ld.lld: error: undefined reference: YAML::LoadFile(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&)
>>> referenced by /home/yushijinhun/ws_lsg_locobot/devel/.private/interbotix_xs_sdk/lib/libinterbotix_xs_sdk.so (disallowed by --no-allow-shlib-undefined)

ld.lld: error: undefined reference: YAML::InvalidNode::~InvalidNode()
>>> referenced by /home/yushijinhun/ws_lsg_locobot/devel/.private/interbotix_xs_sdk/lib/libinterbotix_xs_sdk.so (disallowed by --no-allow-shlib-undefined)

...
```

This PR fixes the linker error.