### PR TITLE
Build ROS Common Drivers on Humble CI

### DIFF
--- a/.github/workflows/xs-humble.yaml
+++ b/.github/workflows/xs-humble.yaml
@@ -21,9 +21,13 @@ jobs:
           - {ROS_DISTRO: humble, ROS_REPO: main}
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
           path: src
+      - name: Prepare Workspace
+        run: |
+          rm src/interbotix_ros_common_drivers/COLCON_IGNORE
       - uses: 'ros-industrial/industrial_ci@master'
-        env: ${{matrix.env}}
+        with:
+          config: ${{toJSON(matrix.env)}}


### PR DESCRIPTION
This PR does the following to the ROS 2 Humble CI workflow:
* Removes the interbotix_ros_common_drivers COLCON_IGNORE, allowing it to build
* Bumps actions/checkout version to 4
* Updates industrial_ci step config