### PR TITLE
Add libhidapi-dev install to CI

### DIFF
--- a/.github/workflows/xs-humble.yaml
+++ b/.github/workflows/xs-humble.yaml
@@ -29,5 +29,8 @@ jobs:
         run: |
           rm src/interbotix_ros_core/interbotix_ros_common_drivers/COLCON_IGNORE
           rm src/interbotix_ros_core/interbotix_ros_xseries/COLCON_IGNORE
+      - name: Install Dependencies
+        run: |
+          sudo apt-get install libhidapi-dev
       - uses: 'ros-industrial/industrial_ci@master'
         env: ${{matrix.env}}


### PR DESCRIPTION
This PR manually installs libhidapi-dev during the Humble CI.