### PR TITLE
Update xs_driver to v0.3.4

### DIFF
--- a/.github/workflows/xs-humble.yaml
+++ b/.github/workflows/xs-humble.yaml
@@ -27,7 +27,7 @@ jobs:
           path: src/interbotix_ros_core
       - name: Prepare Workspace
         run: |
-          rm src/interbotix_ros_core/interbotix_ros_common_drivers/COLCON_IGNORE
+          # rm src/interbotix_ros_core/interbotix_ros_common_drivers/COLCON_IGNORE
           rm src/interbotix_ros_core/interbotix_ros_xseries/COLCON_IGNORE
       - name: Install Dependencies
         run: |


### PR DESCRIPTION
This PR does the following:

* Updates the X-Series driver to [v0.3.4](https://github.com/Interbotix/interbotix_xs_driver/releases/tag/v0.3.4) bringing in the following fixes:
  * https://github.com/Interbotix/interbotix_xs_driver/pull/12
  * https://github.com/Interbotix/interbotix_xs_driver/pull/13
  * Full changelog: * https://github.com/Interbotix/interbotix_xs_driver/compare/v0.3.3...v0.3.4
* Disables the xs-humble workflow on interbotix_ros_common_drivers