### PR TITLE
Fix flake8 E721 issue in xs_sdk_sim

### DIFF
--- a/interbotix_ros_xseries/interbotix_xs_sdk/scripts/xs_sdk_sim.py
+++ b/interbotix_ros_xseries/interbotix_xs_sdk/scripts/xs_sdk_sim.py
@@ -774,7 +774,7 @@ class InterbotixRobotXS(Node):
                 mode = self.motor_map[joint]['mode']
 
                 if 'position' in mode:
-                    if type(self.commands[joint]) == list:
+                    if isinstance(self.commands[joint], list):
                         value = self.commands[joint].pop()
                         if len(self.commands[joint]) == 0:
                             del self.commands[joint]


### PR DESCRIPTION
This PR fixes a flake8 E721 issue in xs_sdk_sim — use `isinstance(obj, type)` instead of `type(obj) == type`.