### PR TITLE
Update xs-rolling CI runner to 24.04

### DIFF
--- a/.github/workflows/xs-rolling.yaml
+++ b/.github/workflows/xs-rolling.yaml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         env:
           - {ROS_DISTRO: rolling, ROS_REPO: main}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
This PR updates the xs-rolling CI to run on Ubuntu 24.04.